### PR TITLE
Automatically reconnect music player upon failure

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -18,7 +18,7 @@ from discord.ext import commands
 from youtube_dl import YoutubeDL
 from async_timeout import timeout
 
-from constants import ytdl_format_options
+from constants import ytdl_format_options, ffmpeg_options
 
 
 ytdl = YoutubeDL(ytdl_format_options)
@@ -68,7 +68,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         else:
             return {"webpage_url": data["webpage_url"], "requester": ctx.author, "title": data["title"]}
 
-        return cls(discord.FFmpegPCMAudio(source), data=data, requester=ctx.author)
+        return cls(discord.FFmpegPCMAudio(source, **ffmpeg_options), data=data, requester=ctx.author)
 
     @classmethod
     async def regather_stream(cls, data, *, loop):
@@ -80,7 +80,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         to_run = partial(ytdl.extract_info, url=data["webpage_url"], download=False)
         data = await loop.run_in_executor(None, to_run)
 
-        return cls(discord.FFmpegPCMAudio(data["url"]), data=data, requester=requester)
+        return cls(discord.FFmpegPCMAudio(data["url"], **ffmpeg_options), data=data, requester=requester)
 
 
 class MusicPlayer:

--- a/constants.py
+++ b/constants.py
@@ -82,6 +82,11 @@ ytdl_format_options = {
     "source_address": "0.0.0.0"  # ipv6 addresses cause issues sometimes
 }
 
+ffmpeg_options = {
+    'before_options': '-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5',
+    'options': '-vn',
+}
+
 # Special
 tortoise_developers = (197918569894379520, 612349409736392928)
 


### PR DESCRIPTION
At the moment, FFmpeg does not have the automatic reconnection option. This means that, upon any form of failure such as a stream link expiring, the bot will cease to play any music. 

This commit fixes that by adding the automatic reconnection option.

**BEFORE:**
![image](https://user-images.githubusercontent.com/48491055/80291280-39795400-8744-11ea-9778-74bf0866f266.png)
**AFTER:**
![image](https://user-images.githubusercontent.com/48491055/80291302-54e45f00-8744-11ea-9b65-429d93d12efd.png)

This reconnection is near instant and should not have any impact upon the user's experience.