### PR TITLE
Automation of dm_unverified using a coroutine task

### DIFF
--- a/bot/api_client.py
+++ b/bot/api_client.py
@@ -144,6 +144,9 @@ class TortoiseAPI(APIClient):
     async def get_member_data(self, member_id: int) -> dict:
         return await self.get(f"members/edit/{member_id}/")
 
+    async def get_all_members(self) -> list:
+        return await self.get("members/")
+
     async def edit_member_roles(self, member: Member, roles_ids: List[int]):
         await self.put(
             f"members/edit/{member.id}/",


### PR DESCRIPTION
Resolves #31 

Small PR that converts the dm_unverified command into a coroutine task, that runs once every 24h based on the guidelines in issue #31 