### PR TITLE
Added speak command in cogs/misc.py

### DIFF
--- a/bot/cogs/misc.py
+++ b/bot/cogs/misc.py
@@ -1,6 +1,7 @@
 import os
 import time
 import asyncio
+from textwrap import wrap
 from random import randint
 
 import psutil
@@ -296,6 +297,30 @@ class Miscellaneous(commands.Cog):
         else:
             await ctx.send(embed=info("Oops! You can't roll that many times. Try a number less than 25",
                            ctx.me, title=""))
+
+    @commands.command()
+    async def speak(self, ctx, *text):
+        """Displays a tortoise with text bubble"""
+        tortoise = r'''
+      \
+       \     ,-"""-.
+        oo._/ \___/ \
+        (____)_/___\__\_)
+            /_//   \\_\ '''
+        lines = wrap(" ".join(text), 40)
+        width = max(map(len, lines))
+        bubble = []
+        bubble.append("  "+"-"*width)
+        if len(lines) == 1:
+            bubble.append("< "+lines[0]+" >")
+        else:
+            bubble.append("/ "+lines[0]+" "*(width - len(lines[0]))+" \\")
+            for line in lines[1:-1]:
+                bubble.append("| "+line+" "*(width - len(line))+" |")
+            bubble.append("\\ "+lines[-1]+" "*(width - len(lines[-1]))+" /")
+        bubble.append("  "+"-"*width)
+        output = "\n".join(bubble) + tortoise
+        await ctx.send(f"```{output}```")
 
 
 def setup(bot):

--- a/bot/cogs/misc.py
+++ b/bot/cogs/misc.py
@@ -302,23 +302,22 @@ class Miscellaneous(commands.Cog):
     async def speak(self, ctx, *text):
         """Displays a tortoise with text bubble"""
         tortoise = r'''
-      \
-       \      ,-"""-.
-         oo._/ \___/ \
-        (____)_/___\__\_)
-            /_//   \\_\ '''
+        \
+         \     ,-"""-.
+          oo._/ \___/ \
+         (____)_/___\__\_)
+             /_//   \\_\ '''
         lines = wrap(" ".join(text), 40)
         width = max(map(len, lines))
-        bubble = []
-        bubble.append("  "+"-"*width)
+        bubble = ["  " + "-" * width]
         if len(lines) == 1:
-            bubble.append("< "+lines[0]+" >")
+            bubble.append("< " + lines[0] + " >")
         else:
-            bubble.append("/ "+lines[0]+" "*(width - len(lines[0]))+" \\")
+            bubble.append("/ " + lines[0] + " " * (width - len(lines[0])) + " \\")
             for line in lines[1:-1]:
-                bubble.append("| "+line+" "*(width - len(line))+" |")
-            bubble.append("\\ "+lines[-1]+" "*(width - len(lines[-1]))+" /")
-        bubble.append("  "+"-"*width)
+                bubble.append("| " + line + " " * (width - len(line)) + " |")
+            bubble.append("\\ " + lines[-1] + " " * (width - len(lines[-1])) + " /")
+        bubble.append("  " + "-" * width)
         output = "\n".join(bubble) + tortoise
         await ctx.send(f"```{output}```")
 

--- a/bot/cogs/misc.py
+++ b/bot/cogs/misc.py
@@ -303,8 +303,8 @@ class Miscellaneous(commands.Cog):
         """Displays a tortoise with text bubble"""
         tortoise = r'''
       \
-       \     ,-"""-.
-        oo._/ \___/ \
+       \      ,-"""-.
+         oo._/ \___/ \
         (____)_/___\__\_)
             /_//   \\_\ '''
         lines = wrap(" ".join(text), 40)


### PR DESCRIPTION
I added a miscellaneous command for issue #147 
It will basically take the given text and display it in a text bubble (like the comics).
Usage: `t.speak text`
Example:
![image](https://user-images.githubusercontent.com/33087753/135746046-60daed78-603d-40a8-a85e-b6f60cfe8e6d.png)

![image](https://user-images.githubusercontent.com/33087753/135746072-0305b492-1713-4022-bbbe-39880881f92f.png)

`t.speak hello sir, do you mind reviewing my pull request?`

![image](https://user-images.githubusercontent.com/33087753/135746014-a298909d-7150-4064-9a5b-b54b1d9ad74d.png)
